### PR TITLE
fix: Player init race condition

### DIFF
--- a/web/src/Player.tsx
+++ b/web/src/Player.tsx
@@ -48,9 +48,9 @@ export default function Player(props: PlayerProps) {
   const [lastVideoId, setLastVideoId] = useState("");
 
   // Initialize the player.
+  const loadedRef = useRef(false);
+  const iframeAPIReadyRef = useRef(false);
   useEffect(() => {
-    let loaded = false;
-    let iframeAPIReady = false;
     function onYTReady() {
       // This is needed because React's StrictMode runs useEffect twice, but
       // there's no way to destroy the side effect of player construction
@@ -124,17 +124,25 @@ export default function Player(props: PlayerProps) {
       });
       (window as any).player = playerRef.current;
     }
-    window.addEventListener("load", () => {
-      console.log("window.addEventListener: load");
-      loaded = true;
-      if (iframeAPIReady) {
-        onYTReady();
-      }
-    });
+    if (window.document.readyState === "complete") {
+      console.log("Document already loaded");
+      loadedRef.current = true;
+    } else {
+      console.log("Setting event listener for load");
+      window.addEventListener("load", () => {
+        const iframeAPIReady = iframeAPIReadyRef.current;
+        console.log("window.addEventListener: load", { iframeAPIReady });
+        loadedRef.current = true;
+        if (iframeAPIReady) {
+          onYTReady();
+        }
+      });
+    }
     // TODO: Add proper typings for these globals and externals.
     (window as any).onYouTubeIframeAPIReady = () => {
-      console.log("window.onYouTubeIframeAPIReady");
-      iframeAPIReady = true;
+      const loaded = loadedRef.current;
+      console.log("window.onYouTubeIframeAPIReady", { loaded });
+      iframeAPIReadyRef.current = true;
       if (loaded) {
         onYTReady();
       }


### PR DESCRIPTION
Fixes #5.

I finally figured out how to reproduce this, by:

1. Using a guest user in Chrome.
2. Visiting the site with the Chrome inspector closed.
3. Debugging against production instead of locally.

This bug only happened under these conditions because it was an initialization race condition. The broken path here was when the document had already finished loading before the `<Player />` initialization effect ran. When this occurred, `loaded` would never be `true`, since `addEventListener('load', f)` would never fire (because the event listener was added _after_ the event had already occurred). To fix this, I added a check for `document.readyState`.

I also moved the local variables out into refs. I don't think this is strictly necessary, since the event handlers and functions are still closed over the same sets of variables, but it made me nervous.